### PR TITLE
Windows-compability fix (and updated README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ You sure need to have a functionnal installation of `pandoc` on your machine and
 
 You can download it from John Mac Farlane dedicated website : [http://johnmacfarlane.net/pandoc](http://johnmacfarlane.net/pandoc)
 
+### Instructions for Windows
+
+After installing `watchdog` and cloning the repository, cd into the
+`python3-pandoc-watch` directory and run:
+
+```
+python setup.py install
+```
+
+You should now be able to run `pandoc-watch` under Windows.
+
 ## How to use `pandoc-watch`
 
 `pandoc-watch` mainly adds an extra argument to the `pandoc` standard options : `-e,--exclude` used to exclude:

--- a/pandocwatch.py
+++ b/pandocwatch.py
@@ -33,6 +33,8 @@ def which(program):
         for path in os.environ["PATH"].split(os.pathsep):
             path = path.strip('"')
             exe_file = os.path.join(path, program)
+            if (sys.platform == "win32"):
+                exe_file += ".exe"
             if is_exe(exe_file):
                 return exe_file
     return None


### PR DESCRIPTION
For locating `pandoc` in `PATH` on Windows (under `which`), the path needs to be appended with ".exe". 

Also updated the README with some brief instructions on how to get running under Windows.